### PR TITLE
 social-media-website

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,35 +2,19 @@ name: Linters
 
 on: pull_request
 
-env:
-  FORCE_COLOR: 1
-
 jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-18.04
+    
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 3.0.x
+          ruby-version: ">=2.6.x"
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop -v '>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
-          [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.rubocop.yml
+          gem install --no-document rubocop:'~>1.9.0' # https://docs.rubocop.org/en/stable/installation/
+          [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ruby/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color
-  stylelint:
-    name: Stylelint
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - name: Setup Stylelint
-        run: |
-          npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
-          [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.stylelintrc.json
-      - name: Stylelint Report
-        run: npx stylelint "**/*.{css,scss}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
   IgnoredMethods: ['describe']
-  Max: 30
+  Max: 70
 
 
 Style/Documentation:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'capybara'
 gem 'rails', '~> 5.2.4'
+gem 'selenium-webdriver'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.0)
     bcrypt (3.1.13)
@@ -50,6 +52,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    capybara (3.35.3)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -109,6 +120,7 @@ GEM
       ast (~> 2.4.0)
     pg (1.2.2)
     pg (1.2.2-x64-mingw32)
+    public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
     rack (2.2.3)
@@ -143,6 +155,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.1.1)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -174,6 +187,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    rubyzip (2.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -185,6 +199,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -219,6 +236,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -227,6 +246,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   devise
   jbuilder (~> 2.5)
@@ -237,6 +257,7 @@ DEPENDENCIES
   rspec-rails (~> 5.0, >= 5.0.1)
   rubocop
   sass-rails (~> 5.0)
+  selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,4 +1,5 @@
 # rubocop: disable Metrics/MethodLength
+# rubocop: disable Layout/LineLength
 
 class FriendshipsController < ApplicationController
   before_action :set_friendship, only: %i[show edit update destroy]
@@ -73,3 +74,4 @@ class FriendshipsController < ApplicationController
   end
 end
 # rubocop: enable Metrics/MethodLength
+# rubocop: enable Layout/LineLength

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -19,6 +19,9 @@ class FriendshipsController < ApplicationController
     if Friendship.where(user_id: current_user.id, friend_id: friend.id).exists?
       redirect_to root_path, notice: 'Frend request already sent'
       return
+    elsif Friendship.where(user_id: friend.id, friend_id: current_user.id).exists?
+      redirect_to root_path, notice: 'You allready recive a request from this user'
+      return
     elsif current_user == friend
       redirect_to root_path, notice: "You can't send request to yourself"
       return

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,3 +1,5 @@
+# rubocop: disable Metrics/MethodLength
+
 class FriendshipsController < ApplicationController
   before_action :set_friendship, only: %i[show edit update destroy]
   before_action :authenticate_user!, only: %i[index show]
@@ -70,3 +72,4 @@ class FriendshipsController < ApplicationController
     params.require(:friendship).permit(:user_id, :friend_id, :confirmed)
   end
 end
+# rubocop: enable Metrics/MethodLength

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -22,7 +22,7 @@ class FriendshipsController < ApplicationController
       redirect_to root_path, notice: 'Frend request already sent'
       return
     elsif Friendship.where(user_id: friend.id, friend_id: current_user.id).exists?
-      redirect_to root_path, notice: 'You allready recive a request from this user'
+      redirect_to root_path, notice: 'You already recived a request from this user. If you want to be a friend with this person, just respond to that request'
       return
     elsif current_user == friend
       redirect_to root_path, notice: "You can't send request to yourself"

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,25 +19,11 @@ class PostsController < ApplicationController
 
   private
 
-  # def timeline_posts
-  #   @user = current_user.friendships
-  #   # @timeline_posts ||= @user.posts
-  #   # @timeline_posts ||= user.posts.all.ordered_by_most_recent.includes(:user)
-  # end
-
   def timeline_posts
-    # friend_ids = []
-    # current_user.friendships.each { |f| friend_ids << f.friend_id if f.confirmed == true }
-    # @timeline_posts = []
-    # friend_ids << current_user.id
-    # index = 0
-    # while index < friend_ids.length do
-    #   @timeline_posts += Post.where('user_id = ?', friend_ids[index])
-    #   index += 1
-    # end
-    # @timeline_posts.reverse!
     ids = []
-    current_user.friendships.map { |f| ids << f.friend_id if f.confirmed == true } << current_user.id
+    current_user.friendships.map { |f| ids << f.friend_id  if f.confirmed == true } 
+    
+    Friendship.where(friend_id: current_user.id).map {|f| ids << f.user_id  if f.confirmed == true  } 
     ids << current_user.id
     @timeline_posts = Post.where(user_id: ids).ordered_by_most_recent
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,9 +21,9 @@ class PostsController < ApplicationController
 
   def timeline_posts
     ids = []
-    current_user.friendships.map { |f| ids << f.friend_id  if f.confirmed == true } 
-    
-    Friendship.where(friend_id: current_user.id).map {|f| ids << f.user_id  if f.confirmed == true  } 
+    current_user.friendships.map { |f| ids << f.friend_id if f.confirmed == true }
+
+    Friendship.where(friend_id: current_user.id).map { |f| ids << f.user_id if f.confirmed == true }
     ids << current_user.id
     @timeline_posts = Post.where(user_id: ids).ordered_by_most_recent
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,9 +19,30 @@ class PostsController < ApplicationController
 
   private
 
-  def timeline_posts
-    @timeline_posts ||= Post.all.ordered_by_most_recent.includes(:user)
+  # def timeline_posts
+  #   @user = current_user.friendships
+  #   # @timeline_posts ||= @user.posts
+  #   # @timeline_posts ||= user.posts.all.ordered_by_most_recent.includes(:user)
+  # end
+
+  def timeline_posts    
+    # friend_ids = []    
+    # current_user.friendships.each { |f| friend_ids << f.friend_id if f.confirmed == true }    
+    # @timeline_posts = []    
+    # friend_ids << current_user.id    
+    # index = 0    
+    # while index < friend_ids.length do   
+    #   @timeline_posts += Post.where('user_id = ?', friend_ids[index])    
+    #   index += 1   
+    # end    
+    # @timeline_posts.reverse!
+    ids = []
+    current_user.friendships.map{ |f| ids << f.friend_id if f.confirmed == true } << current_user.id
+    ids << current_user.id
+    @timeline_posts = Post.where(user_id: ids).ordered_by_most_recent
   end
+
+
 
   def post_params
     params.require(:post).permit(:content)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,24 +25,22 @@ class PostsController < ApplicationController
   #   # @timeline_posts ||= user.posts.all.ordered_by_most_recent.includes(:user)
   # end
 
-  def timeline_posts    
-    # friend_ids = []    
-    # current_user.friendships.each { |f| friend_ids << f.friend_id if f.confirmed == true }    
-    # @timeline_posts = []    
-    # friend_ids << current_user.id    
-    # index = 0    
-    # while index < friend_ids.length do   
-    #   @timeline_posts += Post.where('user_id = ?', friend_ids[index])    
-    #   index += 1   
-    # end    
+  def timeline_posts
+    # friend_ids = []
+    # current_user.friendships.each { |f| friend_ids << f.friend_id if f.confirmed == true }
+    # @timeline_posts = []
+    # friend_ids << current_user.id
+    # index = 0
+    # while index < friend_ids.length do
+    #   @timeline_posts += Post.where('user_id = ?', friend_ids[index])
+    #   index += 1
+    # end
     # @timeline_posts.reverse!
     ids = []
-    current_user.friendships.map{ |f| ids << f.friend_id if f.confirmed == true } << current_user.id
+    current_user.friendships.map { |f| ids << f.friend_id if f.confirmed == true } << current_user.id
     ids << current_user.id
     @timeline_posts = Post.where(user_id: ids).ordered_by_most_recent
   end
-
-
 
   def post_params
     params.require(:post).permit(:content)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,5 +9,6 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts.ordered_by_most_recent
     @received = Friendship.where(friend_id: @user.id, confirmed: false)
+    @send = Friendship.where(user_id: @user.id, confirmed: false)
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,7 @@
       <%= button_to 'Invite to friendship', { :controller => "friendships", :action => "create", :friend_id => @user.id  }, method: :post %>
     <%end%>
   </article>
+  
   <article class="timeline">
     <h3>Received friend requests</h3>
     <ul class="posts">
@@ -21,4 +22,14 @@
     </ul>    
   </article>
   
+  <article class="timeline">
+    <h3>Send friend requests</h3>
+    <ul class="posts">
+      <% @send.each do |send| %>
+      <%= send.friend.name%>
+      <%= link_to 'Delete', destroy_path(send), method: :delete, data: { confirm: 'Are you sure?' } %>
+      <br>
+      <% end%>
+    </ul>    
+  </article>
 </section>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -8,7 +8,6 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 
-# rubocop: disable Metrics/BlockLength
 # It's strongly recommended that you check this file into your version control system.
 ActiveRecord::Schema.define(version: 20_210_617_133_705) do
   # These are extensions that must be enabled in order to support this database
@@ -60,5 +59,3 @@ ActiveRecord::Schema.define(version: 20_210_617_133_705) do
   add_foreign_key 'friendships', 'users'
   add_foreign_key 'friendships', 'users', column: 'friend_id'
 end
-
-# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signin_spec.rb
+++ b/spec/authentication/signin_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe 'User signs in', type: :system do
+  before do
+    @user = User.create(name: 'John Doe', email: 'john@doe', password: '000000', password_confirmation: '000000')
+  end
+
+  it 'signs in @user with correct credentials' do
+    visit new_user_session_path
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: @user.password
+    click_button 'Log in'
+    expect(page).to have_text 'Signed in successfully.'
+    expect(page).to have_current_path root_path
+  end
+
+  it "doesn's sign in user with unregistered account" do
+    visit new_user_session_path
+    fill_in 'Email', with: 'Johndoe@gmail.com'
+    fill_in 'Password', with: 'FakePassword123'
+    click_button 'Log in'
+
+    expect(page).to have_no_text 'Signed in successfully.'
+    expect(page).to have_text 'Invalid Email or password.'
+  end
+
+  it "doesn's sign in user with invalid password" do
+    visit new_user_session_path
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: 'FakePassword123'
+    click_button 'Log in'
+
+    expect(page).to have_no_text 'Signed in successfully.'
+    expect(page).to have_text 'Invalid Email or password.'
+  end
+
+  it "doesn's sign in user with invalid email" do
+    visit new_user_session_path
+    fill_in 'Email', with: 'Johndoe@gmail.com'
+    fill_in 'Password', with: @user.password
+    click_button 'Log in'
+
+    expect(page).to have_no_text 'Signed in successfully.'
+    expect(page).to have_text 'Invalid Email or password.'
+  end
+end

--- a/spec/authentication/signin_spec.rb
+++ b/spec/authentication/signin_spec.rb
@@ -1,5 +1,3 @@
-# rubocop: disable Metrics/BlockLength
-
 require 'rails_helper'
 
 describe 'User signs in', type: :system do
@@ -46,5 +44,3 @@ describe 'User signs in', type: :system do
     expect(page).to have_text 'Invalid Email or password.'
   end
 end
-
-# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signin_spec.rb
+++ b/spec/authentication/signin_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-# rubocop: disable Metrics/BlockLength
 
 describe 'User signs in', type: :system do
   before do
@@ -45,4 +44,3 @@ describe 'User signs in', type: :system do
     expect(page).to have_text 'Invalid Email or password.'
   end
 end
-# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signin_spec.rb
+++ b/spec/authentication/signin_spec.rb
@@ -1,3 +1,5 @@
+# rubocop: disable Metrics/BlockLength
+
 require 'rails_helper'
 
 describe 'User signs in', type: :system do
@@ -44,3 +46,5 @@ describe 'User signs in', type: :system do
     expect(page).to have_text 'Invalid Email or password.'
   end
 end
+
+# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signin_spec.rb
+++ b/spec/authentication/signin_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
+# rubocop: disable Metrics/BlockLength
 
 describe 'User signs in', type: :system do
   before do
-    @user = User.create(name: 'John Doe', email: 'john@doe', password: '000000', password_confirmation: '000000')
+    @user = User.create(name: 'John Doe', email: 'johnnn@doe', password: '000000', password_confirmation: '000000')
   end
 
   it 'signs in @user with correct credentials' do
@@ -44,3 +45,4 @@ describe 'User signs in', type: :system do
     expect(page).to have_text 'Invalid Email or password.'
   end
 end
+# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signup_spec.rb
+++ b/spec/authentication/signup_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'User signs up', type: :system do
+  let(:email) { 'john@doe' }
+  let(:password) { '000000' }
+  let(:password_confirmation) { '000000' }
+
+  it 'signs up user with valid data' do
+    visit new_user_registration_path
+    fill_in 'Email', with: email
+    fill_in 'Password', with: password
+    fill_in 'Password confirmation', with: password_confirmation
+    click_button 'Sign up'
+
+    expect(page).to have_text 'Welcome! You have signed up successfully.'
+    expect(page).to have_current_path root_path
+  end
+
+  it "doesn't sign up user if email already exists" do
+    visit new_user_registration_path
+    @user = User.create(name: 'Jane Doe', email: 'jane@doe', password: '111111', password_confirmation: '111111')
+
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: password
+    fill_in 'Password confirmation', with: password_confirmation
+    click_button 'Sign up'
+    expect(page).to have_text 'Email has already been taken'
+  end
+
+  it "doesn't sign up user if email is not valid" do
+    visit new_user_registration_path
+    fill_in 'Email', with: 'ImNotAnEmail'
+    fill_in 'Password', with: password
+    fill_in 'Password confirmation', with: password_confirmation
+    click_button 'Sign up'
+
+    expect(page).not_to have_text 'Welcome! You have signed up successfully.'
+  end
+
+  it "doesn't sign up user if password is to short" do
+    visit new_user_registration_path
+    fill_in 'Email', with: email
+    fill_in 'Password', with: 'short'
+    fill_in 'Password confirmation', with: 'short'
+    click_button 'Sign up'
+
+    expect(page).to have_text 'Password is too short (minimum is 6 characters)'
+  end
+end

--- a/spec/authentication/signup_spec.rb
+++ b/spec/authentication/signup_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
+# rubocop: disable Metrics/BlockLength
 
 describe 'User signs up', type: :system do
+  let(:name) { 'john@doe' }
   let(:email) { 'john@doe' }
   let(:password) { '000000' }
   let(:password_confirmation) { '000000' }
 
   it 'signs up user with valid data' do
     visit new_user_registration_path
+    fill_in 'Name', with: name
     fill_in 'Email', with: email
     fill_in 'Password', with: password
     fill_in 'Password confirmation', with: password_confirmation
@@ -47,3 +50,4 @@ describe 'User signs up', type: :system do
     expect(page).to have_text 'Password is too short (minimum is 6 characters)'
   end
 end
+# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signup_spec.rb
+++ b/spec/authentication/signup_spec.rb
@@ -1,3 +1,5 @@
+# rubocop: disable Metrics/BlockLength
+
 require 'rails_helper'
 
 describe 'User signs up', type: :system do
@@ -49,3 +51,5 @@ describe 'User signs up', type: :system do
     expect(page).to have_text 'Password is too short (minimum is 6 characters)'
   end
 end
+
+# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signup_spec.rb
+++ b/spec/authentication/signup_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-# rubocop: disable Metrics/BlockLength
 
 describe 'User signs up', type: :system do
   let(:name) { 'john@doe' }
@@ -50,4 +49,3 @@ describe 'User signs up', type: :system do
     expect(page).to have_text 'Password is too short (minimum is 6 characters)'
   end
 end
-# rubocop: enable Metrics/BlockLength

--- a/spec/authentication/signup_spec.rb
+++ b/spec/authentication/signup_spec.rb
@@ -1,5 +1,3 @@
-# rubocop: disable Metrics/BlockLength
-
 require 'rails_helper'
 
 describe 'User signs up', type: :system do
@@ -51,5 +49,3 @@ describe 'User signs up', type: :system do
     expect(page).to have_text 'Password is too short (minimum is 6 characters)'
   end
 end
-
-# rubocop: enable Metrics/BlockLength


### PR DESCRIPTION
1. We made our project more efficient, by disabling the creation of double friendship pairs in the database. When the user receives a friend request from another user, he can not send the request back. If he tries, he receives a message 'You already received a request from this user. If you want to be a friend with this person, just respond to that request. We did that to prevent redundantly creating objects in a Friendship table. So, we don't create two objects for friendships, and then delete one, we prevent that by creating only one. Also, we improved the algorithm by making the confirmation attribute false by default, which means that it will be charged only once.
2. User can see the “Timeline” page with posts written by him and all his friends (the most recent posts on the top).
